### PR TITLE
Update Serverless versions + add layers

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,5 +1,5 @@
 {
-  "project_name": "test",
-  "serverless_version": ["1.28.0", "1.27.2", "1.26.1"],
+  "project_name": "example",
+  "serverless_version": ["1.35.1", "1.28.0", "1.27.2"],
   "AWS_REGION": ["us-east-2", "us-east-1", "us-west-2"]
 }

--- a/{{cookiecutter.project_name}}/serverless/handler.py
+++ b/{{cookiecutter.project_name}}/serverless/handler.py
@@ -2,13 +2,11 @@
 import json
 import sys
 
-from pathlib import Path
-
 # pylint: disable=wrong-import-position
 
-# Munge our sys path so libs can be found
-LIB = Path(__file__).resolve().parent / 'lib'
-sys.path.insert(0, str(LIB))
+# Update our sys path libs stored in our Layer can be found. All imports for additional libraries
+# should come *after* this line.
+sys.path.insert(0, '/opt')
 
 
 def hello(event, context):

--- a/{{cookiecutter.project_name}}/serverless/serverless.yml
+++ b/{{cookiecutter.project_name}}/serverless/serverless.yml
@@ -67,9 +67,22 @@ package:
 #       Description: "Description for the output"
 #       Value: "Some output value"
 
+# Set our lib directory to be installed as a layer. This makes deployments for individual functions
+# extremely fast:
+#
+#   make deploy function=function_name
+#
+# Note that a full deployment will re-deploy the layer due to the way that CloudFormation works.
+layers:
+  {{cookiecutter.project_name|title}}Lib:
+    name: {{cookiecutter.project_name|title}}Lib-${env:ENV}
+    path: lib
+
 functions:
   hello:
     handler: handler.hello
+    layers:
+      - Ref: {{cookiecutter.project_name|title}}LibLambdaLayer
 #    The following are a few example events you can configure
 #    Check the event documentation for details
 #       https://serverless.com/framework/docs/providers/aws/guide/events/


### PR DESCRIPTION
Why
---

- We were behind with Serverless versions
- Using layers for python libs is quite nice

This change addresses the need by
---------------------------------

- Adding a `layer` for system libraries, which makes (function) deployments faster
- Update the Serverless versions